### PR TITLE
Add Float & Bool Support

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "glaml"
-version = "1.0.1"
+version = "2.0.0"
 
 licences = ["MIT"]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,12 +2,12 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.38.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "663CF11861179AF415A625307447775C09404E752FF99A24E2057C835319F1BE" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_stdlib", version = "0.41.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "1B2F80CB1B66B027E3198A2FF71EF3F2F31DF89ED97AD606F25FD387A4C3C1EF" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
   { name = "yamerl", version = "0.10.0", build_tools = ["rebar3"], requirements = [], otp_app = "yamerl", source = "hex", outer_checksum = "346ADB2963F1051DC837A2364E4ACF6EB7D80097C0F53CBDC3046EC8EC4B4E6E" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
-yamerl = { version = ">= 0.10.0 and < 1.0.0"}
+yamerl = { version = ">= 0.10.0 and < 1.0.0" }

--- a/src/glaml.gleam
+++ b/src/glaml.gleam
@@ -8,7 +8,7 @@ pub type Document {
 
 /// A Document Error dispatched by yamerl.
 /// It contains a string - `msg` and a tuple of 2 integers - `loc`.
-/// 
+///
 /// The location is: `#(line, column)`.
 ///
 pub type DocError {
@@ -34,35 +34,35 @@ pub type PathRule {
 }
 
 /// Parses the YAML file at `path` and returns either `Ok(Document(...))` or `Error(DocError(...))`.
-/// 
+///
 @external(erlang, "yaml_ffi", "parse_file")
 pub fn parse_file(path: String) -> Result(Document, DocError)
 
 /// Parses the YAML string and returns either `Ok(Document(...))` or `Error(DocError(...))`.
-/// 
+///
 @external(erlang, "yaml_ffi", "parse_string")
 pub fn parse_string(string: String) -> Result(Document, DocError)
 
 /// Returns the root node of the `Document`.
-/// 
+///
 pub fn doc_node(doc: Document) -> DocNode {
   doc.root
 }
 
 /// Does the same thing as `get` but instead of a list of `PathRule`s,
 /// you write a `String` that will get parsed into a list of `PathRule`s for you.
-/// 
+///
 /// ## Syntax
-/// 
+///
 /// ```gleam
 /// "some_key" == [Map("some_key")]
 /// "#0" == [Seq(0)]
 /// "combination.#0.of.these" == [Map("combination"), Seq(0), Map("of"), Map("these")]
-/// 
+///
 /// // You can write as many dots as you want - an empty key points at the current node.
 /// "...test..#0." == [Map("test"), Seq(0)]
 /// ```
-/// 
+///
 pub fn sugar(
   from node: DocNode,
   to path: String,
@@ -99,9 +99,9 @@ fn build_sugar(sugar: List(String)) -> Result(List(PathRule), Nil) {
 }
 
 /// Traverses the `DocNode` and tries to find another `DocNode` by matching the `PathRule`s.
-/// 
+///
 /// ## Example
-/// 
+///
 /// ```gleam
 /// let assert Ok(doc) = parse_string("
 /// employees:
@@ -113,16 +113,16 @@ fn build_sugar(sugar: List(String)) -> Result(List(PathRule), Nil) {
 ///     field: Networking
 /// ")
 /// let doc = doc_node(doc)
-/// 
+///
 /// get(doc, [Map("employees"), Seq(0), Map("field")])
 /// // -> Ok(DocNodeStr("Database Infrastructure"))
-/// 
+///
 /// get(doc, [Map("employees"), Seq(1), Map("passwords"), Seq(0)])
 /// //                                  ~~~~~~~~~~~~~~~~
 /// //                                    | reading backwards
 /// // -> Error(NodeNotFound("reverse_idx:1,map:passwords"))
 /// ```
-/// 
+///
 pub fn get(
   from node: DocNode,
   to path: List(PathRule),

--- a/src/glaml.gleam
+++ b/src/glaml.gleam
@@ -17,6 +17,7 @@ pub type DocError {
 
 pub type DocNode {
   DocNodeNil
+  DocNodeBool(bool: Bool)
   DocNodeStr(string: String)
   DocNodeInt(int: Int)
   DocNodeFloat(float: Float)

--- a/src/glaml.gleam
+++ b/src/glaml.gleam
@@ -19,6 +19,7 @@ pub type DocNode {
   DocNodeNil
   DocNodeStr(string: String)
   DocNodeInt(int: Int)
+  DocNodeFloat(float: Float)
   DocNodeSeq(nodes: List(DocNode))
   DocNodeMap(nodes: List(#(DocNode, DocNode)))
 }

--- a/src/yaml_ffi.erl
+++ b/src/yaml_ffi.erl
@@ -12,6 +12,7 @@
     {doc_node_map, list({doc_node(), doc_node()})}
     | {doc_node_seq, list(doc_node())}
     | {doc_node_str, binary()}
+    | {doc_node_bool, boolean()}
     | {doc_node_int, integer()}
     | {doc_node_float, float()}
     | doc_node_nil.
@@ -85,6 +86,10 @@ from_yamerl_node(YamerlNode) ->
             doc_node_nil;
         {yamerl_str, yamerl_node_str, _, _Line, String} ->
             {doc_node_str, list_to_binary(String)};
+        {yamerl_bool, yamerl_node_bool, _, _Line, true} ->
+            {doc_node_bool, true};
+        {yamerl_bool, yamerl_node_bool, _, _Line, false} ->
+            {doc_node_bool, false};
         {yamerl_int, yamerl_node_int, _, _Line, Integer} ->
             {doc_node_int, Integer};
         {yamerl_float, yamerl_node_float, _, _Line, Float} ->

--- a/src/yaml_ffi.erl
+++ b/src/yaml_ffi.erl
@@ -13,6 +13,7 @@
     | {doc_node_seq, list(doc_node())}
     | {doc_node_str, binary()}
     | {doc_node_int, integer()}
+    | {doc_node_float, float()}
     | doc_node_nil.
 
 % public
@@ -86,6 +87,8 @@ from_yamerl_node(YamerlNode) ->
             {doc_node_str, list_to_binary(String)};
         {yamerl_int, yamerl_node_int, _, _Line, Integer} ->
             {doc_node_int, Integer};
+        {yamerl_float, yamerl_node_float, _, _Line, Float} ->
+            {doc_node_float, Float};
         {yamerl_seq, yamerl_node_seq, _, _Line, Elements, _Count} ->
             {doc_node_seq, from_yamerl_nodes(Elements)};
         {yamerl_map, yamerl_node_map, _, _Line, Elements} ->


### PR DESCRIPTION
This PR adds `Float` & `Bool` support to `DocNode`. Since this could be a breaking change for some users, I bumped the version number from 1.x to 2.x.

All dependencies have been updated as well.