### PR TITLE
replace deprecated `string.drop_left` with `string.drop_start`

### DIFF
--- a/src/glaml.gleam
+++ b/src/glaml.gleam
@@ -83,7 +83,7 @@ fn build_sugar(sugar: List(String)) -> Result(List(PathRule), Nil) {
     [elem, ..tail] ->
       case string.starts_with(elem, "#") {
         True ->
-          case int.parse(string.drop_left(elem, 1)) {
+          case int.parse(string.drop_start(elem, 1)) {
             Ok(idx) ->
               case build_sugar(tail) {
                 Ok(tail) -> Ok([Seq(idx), ..tail])


### PR DESCRIPTION
`string.drop_left` was deprecated, and `string.drop_start` is supposed to be used instead.

This PR addresses that and stops the deprecation warning that shows up.